### PR TITLE
fix: Package index using old class names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import KiwiConnector from './core/kiwiConnector';
 import {
 	RpcResult,
 	RpcParam,
-	IServerDetails
+	ServerDetails
 } from './core/networkTypes';
 
 // Management
@@ -92,7 +92,7 @@ export {
 	KiwiConnector,
 	RpcResult,
 	RpcParam,
-	IServerDetails,
+	ServerDetails,
 	// Management
 	Build,
 	BuildValues,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,6 +76,7 @@
   "exclude": [
 		"test/**/*",
 		"src/**/*.test.ts",
-    "src/__mocks__/*"
+    "src/__mocks__/*",
+    "src/utils/prettyPrintJson.ts"
   ]
 }


### PR DESCRIPTION
Accidentally broke the package's index file while refactoring class names.
Fix the index file, and omit a debug function from being packed in the NPM module.